### PR TITLE
Easier to use registration function + bug fixes.

### DIFF
--- a/AncientScepter/AncientScepterItem.cs
+++ b/AncientScepter/AncientScepterItem.cs
@@ -731,7 +731,7 @@ namespace AncientScepter
                     {
                         if (stridesInteractionMode == StridesInteractionMode.ScepterTakesPrecedence && hasHeresyForSlot(targetSlot))
                         {
-                            self.skillLocator.utility.UnsetSkillOverride(self, CharacterBody.CommonAssets.lunarUtilityReplacementSkillDef, GenericSkill.SkillOverridePriority.Replacement);
+                            self.skillLocator.GetSkill(targetSlot).UnsetSkillOverride(self, heresyDefs[targetSlot], GenericSkill.SkillOverridePriority.Replacement);
                         }
                         targetSkill.SetSkillOverride(self, replVar.replDef, GenericSkill.SkillOverridePriority.Upgrade);
                     }
@@ -740,7 +740,7 @@ namespace AncientScepter
                         targetSkill.UnsetSkillOverride(self, replVar.replDef, GenericSkill.SkillOverridePriority.Upgrade);
                         if (stridesInteractionMode == StridesInteractionMode.ScepterTakesPrecedence && hasHeresyForSlot(targetSlot))
                         {
-                            self.skillLocator.utility.SetSkillOverride(self, CharacterBody.CommonAssets.lunarUtilityReplacementSkillDef, GenericSkill.SkillOverridePriority.Replacement);
+                            self.skillLocator.GetSkill(targetSlot).SetSkillOverride(self, heresyDefs[targetSlot], GenericSkill.SkillOverridePriority.Replacement);
                         }
                     }
 

--- a/AncientScepter/AncientScepterItem.cs
+++ b/AncientScepter/AncientScepterItem.cs
@@ -511,6 +511,7 @@ namespace AncientScepter
             On.RoR2.CharacterBody.OnInventoryChanged += On_CBOnInventoryChanged;
             On.RoR2.CharacterMaster.GetDeployableSameSlotLimit += On_CMGetDeployableSameSlotLimit;
             On.RoR2.GenericSkill.SetSkillOverride += On_GSSetSkillOverride;
+            RoR2.Run.onRunStartGlobal += On_RunStartGlobal;
 
             foreach (var skill in skills)
             {
@@ -583,10 +584,16 @@ namespace AncientScepter
             public SkillSlot slotIndex;
             public int variantIndex;
             public SkillDef replDef;
+            public SkillDef trgtDef;
         }
 
         private readonly List<ScepterReplacer> scepterReplacers = new List<ScepterReplacer>();
-        private readonly Dictionary<string, SkillSlot> scepterSlots = new Dictionary<string, SkillSlot>();
+        private readonly Dictionary<SkillSlot,SkillDef> heresyDefs = new Dictionary<SkillSlot,SkillDef>{
+            {SkillSlot.Primary,CharacterBody.CommonAssets.lunarPrimaryReplacementSkillDef},
+            {SkillSlot.Secondary,CharacterBody.CommonAssets.lunarSecondaryReplacementSkillDef},
+            {SkillSlot.Utility,CharacterBody.CommonAssets.lunarUtilityReplacementSkillDef},
+            {SkillSlot.Special,CharacterBody.CommonAssets.lunarSpecialReplacementSkillDef}
+        };
 
         public bool RegisterScepterSkill(SkillDef replacingDef, string targetBodyName, SkillSlot targetSlot, int targetVariant)
         {
@@ -602,8 +609,30 @@ namespace AncientScepter
                 scepterReplacers.Remove(firstMatch);
             }
             scepterReplacers.Add(new ScepterReplacer { bodyName = targetBodyName, slotIndex = targetSlot, variantIndex = targetVariant, replDef = replacingDef });
-            scepterSlots[targetBodyName] = targetSlot;
             return true;
+        }
+
+        public bool RegisterScepterSkill(SkillDef replacingDef, string targetBodyName, SkillDef targetDef)
+        {
+            ScepterReplacer firstMatch = scepterReplacers.FirstOrDefault(x => x.bodyName == targetBodyName && (x.trgtDef == targetDef));
+            if (firstMatch != null)
+            {
+                AncientScepterMain._logger.LogMessage($"Replacing scepter skill for \"{targetBodyName}\" ({firstMatch.replDef.skillName}) with ({replacingDef.skillName})");
+                scepterReplacers.Remove(firstMatch);
+            }
+            scepterReplacers.Add(new ScepterReplacer { bodyName = targetBodyName, slotIndex = SkillSlot.None, variantIndex = -1, replDef = replacingDef,trgtDef = targetDef });
+            return true;
+        }
+
+        private void On_RunStartGlobal(Run run){
+            foreach(ScepterReplacer repdef in scepterReplacers.Where(x => x.trgtDef == null)){
+                var prefab = BodyCatalog.FindBodyPrefab(repdef.bodyName);
+                var locator = prefab.GetComponent<SkillLocator>();
+                if(locator && repdef.slotIndex != SkillSlot.None && repdef.variantIndex >= 0){
+                  repdef.trgtDef = locator.GetSkill(repdef.slotIndex).skillFamily.variants[repdef.variantIndex].skillDef;
+                }
+            }
+            Run.onRunStartGlobal -= On_RunStartGlobal;
         }
 
         private bool handlingInventory = false;
@@ -691,14 +720,13 @@ namespace AncientScepter
                 var repl = scepterReplacers.FindAll(x => x.bodyName == bodyName);
                 if (repl.Count > 0)
                 {
-                    SkillSlot targetSlot = scepterSlots[bodyName];
-                    if (targetSlot == SkillSlot.Utility && stridesInteractionMode == StridesInteractionMode.ScepterRerolls && hasHeresyForSlot(targetSlot)) return false;
-                    var targetSkill = self.skillLocator.GetSkill(targetSlot);
+                    var curSkills = self.skillLocator.allSkills.Select((skill) => skill.skillDef);
+                    ScepterReplacer replVar = repl.Find((x) => curSkills.Contains(x.trgtDef));
+                    if(replVar == null) return false;
+                    GenericSkill targetSkill = self.skillLocator.FindSkillByDef(replVar.trgtDef);
+                    SkillSlot targetSlot = (replVar.slotIndex == SkillSlot.None)? self.skillLocator.FindSkillSlot(targetSkill) : replVar.slotIndex;
                     if (!targetSkill) return false;
-                    var targetSlotIndex = self.skillLocator.GetSkillSlotIndex(targetSkill);
-                    var targetVariant = self.master.loadout.bodyLoadoutManager.GetSkillVariant(self.bodyIndex, targetSlotIndex);
-                    var replVar = repl.Find(x => x.variantIndex == targetVariant);
-                    if (replVar == null) return false;
+                    if (stridesInteractionMode == StridesInteractionMode.ScepterRerolls && hasHeresyForSlot(targetSlot) && replVar.trgtDef != heresyDefs[targetSlot]) return false;
                     if (!forceOff && GetCount(self) > 0)
                     {
                         if (stridesInteractionMode == StridesInteractionMode.ScepterTakesPrecedence && hasHeresyForSlot(targetSlot))

--- a/AncientScepter/AncientScepterMain.cs
+++ b/AncientScepter/AncientScepterMain.cs
@@ -62,6 +62,16 @@ namespace AncientScepter
             Language.onCurrentLanguageChanged += Language_onCurrentLanguageChanged;
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        public static void doBetterUI()
+        {
+            BetterUI.Buffs.RegisterBuffInfo(AncientScepterMain.perishSongDebuff,
+                "STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_NAME",
+                "STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_DESC");
+            LanguageAPI.Add("STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_NAME", "Perish Song");
+            LanguageAPI.Add("STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_DESC", "After 30 seconds, take 5000% damage from the Heretic that inflicted you.");
+        }
+
         public static void SetupBuffs()
         {
             perishSongDebuff = ScriptableObject.CreateInstance<BuffDef>();
@@ -78,11 +88,7 @@ namespace AncientScepter
             }
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.Buffs.RegisterBuffInfo(AncientScepterMain.perishSongDebuff,
-                    "STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_NAME",
-                    "STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_DESC");
-                LanguageAPI.Add("STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_NAME", "Perish Song");
-                LanguageAPI.Add("STANDALONEANCIENTSCEPTER_BUFF_PERISHSONG_DESC", "After 30 seconds, take 5000% damage from the Heretic that inflicted you.");
+               doBetterUI();
             }
         }
 

--- a/AncientScepter/ScepterSkills/ArtificerFlamethrower2.cs
+++ b/AncientScepter/ScepterSkills/ArtificerFlamethrower2.cs
@@ -93,11 +93,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MageBodyFlamethrower"));
-                BetterUI.ProcCoefficientCatalog.AddToSkill(myDef.skillName, "Fire Cloud", 0);
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+            BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MageBodyFlamethrower"));
+            BetterUI.ProcCoefficientCatalog.AddToSkill(myDef.skillName, "Fire Cloud", 0);
+        } 
         internal override void LoadBehavior()
         {
             IL.EntityStates.Mage.Weapon.Flamethrower.FireGauntlet += IL_FlamethrowerFireGauntlet;

--- a/AncientScepter/ScepterSkills/ArtificerFlyUp2.cs
+++ b/AncientScepter/ScepterSkills/ArtificerFlyUp2.cs
@@ -40,10 +40,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MageBodyFlyUp"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+            BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MageBodyFlyUp"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Mage.FlyUpState.OnEnter += On_FlyUpStateEnter;

--- a/AncientScepter/ScepterSkills/Bandit2ResetRevolver2.cs
+++ b/AncientScepter/ScepterSkills/Bandit2ResetRevolver2.cs
@@ -39,10 +39,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ResetRevolver"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+            BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ResetRevolver"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Bandit2.Weapon.BaseFireSidearmRevolverState.OnEnter += BaseFireSidearmRevolverState_OnEnter;

--- a/AncientScepter/ScepterSkills/Bandit2SkullRevolver2.cs
+++ b/AncientScepter/ScepterSkills/Bandit2SkullRevolver2.cs
@@ -50,9 +50,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("SkullRevolver"));
+                doBetterUI();
             }
         }
+
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+            BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("SkullRevolver"));
+        } 
 
         internal override void LoadBehavior()
         {

--- a/AncientScepter/ScepterSkills/CaptainAirstrike2.cs
+++ b/AncientScepter/ScepterSkills/CaptainAirstrike2.cs
@@ -58,9 +58,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
+                doBetterUI();
+            }
+        }
+
+        
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
                 BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CallAirstrike"));
                 BetterUI.ProcCoefficientCatalog.AddSkill(myCallDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CallAirstrike"));
-            }
         }
 
         internal override void LoadBehavior()

--- a/AncientScepter/ScepterSkills/CaptainAirstrikeAlt2.cs
+++ b/AncientScepter/ScepterSkills/CaptainAirstrikeAlt2.cs
@@ -128,13 +128,18 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CallAirstrikeAlt"));
-                BetterUI.ProcCoefficientCatalog.AddToSkill(myDef.skillName, "Irradiate", 0);
-                BetterUI.ProcCoefficientCatalog.AddSkill(myCallDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CallAirstrikeAlt"));
-                BetterUI.ProcCoefficientCatalog.AddToSkill(myCallDef.skillName, "Irradiate", 0);
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+            BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CallAirstrikeAlt"));
+            BetterUI.ProcCoefficientCatalog.AddToSkill(myDef.skillName, "Irradiate", 0);
+            BetterUI.ProcCoefficientCatalog.AddSkill(myCallDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CallAirstrikeAlt"));
+            BetterUI.ProcCoefficientCatalog.AddToSkill(myCallDef.skillName, "Irradiate", 0);
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Captain.Weapon.SetupAirstrike.OnEnter += On_SetupAirstrikeStateEnter;

--- a/AncientScepter/ScepterSkills/CommandoBarrage2.cs
+++ b/AncientScepter/ScepterSkills/CommandoBarrage2.cs
@@ -45,10 +45,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CommandoBodyBarrage"));
+                doBetterUI();
             }
         }
 
+        
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+            BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CommandoBodyBarrage"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Commando.CommandoWeapon.FireBarrage.OnEnter += On_FireBarrage_Enter;

--- a/AncientScepter/ScepterSkills/CommandoGrenade2.cs
+++ b/AncientScepter/ScepterSkills/CommandoGrenade2.cs
@@ -49,10 +49,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ThrowGrenade"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ThrowGrenade"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.GenericProjectileBaseState.FireProjectile += On_FireFMJFire;

--- a/AncientScepter/ScepterSkills/CrocoDisease2.cs
+++ b/AncientScepter/ScepterSkills/CrocoDisease2.cs
@@ -59,10 +59,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CrocoDisease"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CrocoDisease"));
+        } 
         internal override void LoadBehavior()
         {
             On.RoR2.Orbs.LightningOrb.OnArrival += On_LightningOrbArrival;

--- a/AncientScepter/ScepterSkills/EngiTurret2.cs
+++ b/AncientScepter/ScepterSkills/EngiTurret2.cs
@@ -42,8 +42,14 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("EngiBodyPlaceTurret"));
+                doBetterUI();
             }
         }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("EngiBodyPlaceTurret"));
+        } 
     }
 }

--- a/AncientScepter/ScepterSkills/HereticNevermore2.cs
+++ b/AncientScepter/ScepterSkills/HereticNevermore2.cs
@@ -50,11 +50,17 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, "Sing", 0);
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, "Perish Song Activation", 0);
+                doBetterUI();
             }
 
         }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, "Sing", 0);
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, "Perish Song Activation", 0);
+        } 
         public static float GetEstimatedDamageForPerishSong()
         {
             return 18 + 3.6f * TeamManager.instance.GetTeamLevel(TeamIndex.Player);

--- a/AncientScepter/ScepterSkills/HuntressBallista2.cs
+++ b/AncientScepter/ScepterSkills/HuntressBallista2.cs
@@ -55,11 +55,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("AimArrowSnipe"));
-                BetterUI.ProcCoefficientCatalog.AddSkill(myCtxDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("AimArrowSnipe"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("AimArrowSnipe"));
+                BetterUI.ProcCoefficientCatalog.AddSkill(myCtxDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("AimArrowSnipe"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Huntress.AimArrowSnipe.OnEnter += On_AimArrowSnipeEnter;

--- a/AncientScepter/ScepterSkills/HuntressRain2.cs
+++ b/AncientScepter/ScepterSkills/HuntressRain2.cs
@@ -64,10 +64,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("HuntressBodyArrowRain"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("HuntressBodyArrowRain"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Huntress.ArrowRain.DoFireArrowRain += On_ArrowRain_DoFireArrowRain;

--- a/AncientScepter/ScepterSkills/LoaderChargeFist2.cs
+++ b/AncientScepter/ScepterSkills/LoaderChargeFist2.cs
@@ -41,10 +41,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("BigPunch"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("BigPunch"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Loader.BaseSwingChargedFist.OnEnter += on_BaseSwingChargedFistEnter;

--- a/AncientScepter/ScepterSkills/LoaderChargeZapFist2.cs
+++ b/AncientScepter/ScepterSkills/LoaderChargeZapFist2.cs
@@ -53,10 +53,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ChargeZapFist"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ChargeZapFist"));
+        } 
         internal override void LoadBehavior()
         {
             IL.EntityStates.Loader.SwingZapFist.OnMeleeHitAuthority += IL_SwingZapFistMeleeHit;

--- a/AncientScepter/ScepterSkills/MercEvis2.cs
+++ b/AncientScepter/ScepterSkills/MercEvis2.cs
@@ -41,10 +41,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MercBodyEvis"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MercBodyEvis"));
+        } 
         internal override void LoadBehavior()
         {
             GlobalEventManager.onCharacterDeathGlobal += Evt_GEMOnCharacterDeathGlobal;

--- a/AncientScepter/ScepterSkills/MercEvisProjectile2.cs
+++ b/AncientScepter/ScepterSkills/MercEvisProjectile2.cs
@@ -41,10 +41,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MercBodyEvisProjectile"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("MercBodyEvisProjectile"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.GenericProjectileBaseState.OnEnter += On_FireFMJEnter;

--- a/AncientScepter/ScepterSkills/RailgunnerCryo2.cs
+++ b/AncientScepter/ScepterSkills/RailgunnerCryo2.cs
@@ -58,11 +58,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("RailgunnerBodyChargeSnipeCryo"));
-                BetterUI.ProcCoefficientCatalog.AddSkill(myFireDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("RailgunnerBodyFireSnipeCryo"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("RailgunnerBodyChargeSnipeCryo"));
+                BetterUI.ProcCoefficientCatalog.AddSkill(myFireDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("RailgunnerBodyFireSnipeCryo"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Railgunner.Weapon.FireSnipeCryo.ModifyBullet += FireSnipeCryo_ModifyBullet;

--- a/AncientScepter/ScepterSkills/RailgunnerSuper2.cs
+++ b/AncientScepter/ScepterSkills/RailgunnerSuper2.cs
@@ -59,14 +59,19 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
+                doBetterUI();
+            }
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
                 //BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("RailgunnerBodyChargeSnipeSuper"));
                 //BetterUI.ProcCoefficientCatalog.AddSkill(myFireDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("RailgunnerBodyFireSnipeSuper"));
 
                 BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, "Projectile", 3.5f);
                 BetterUI.ProcCoefficientCatalog.AddSkill(myFireDef.skillName, "Projectile", 3.5f);
-            }
-        }
-
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Railgunner.Weapon.BaseFireSnipe.ModifyBullet += BaseFireSnipe_ModifyBullet;

--- a/AncientScepter/ScepterSkills/ToolbotDash2.cs
+++ b/AncientScepter/ScepterSkills/ToolbotDash2.cs
@@ -39,11 +39,16 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ToolbotBodyToolbotDash"));
-                BetterUI.ProcCoefficientCatalog.AddToSkill(myDef.skillName, "Explosion", 1f);
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("ToolbotBodyToolbotDash"));
+                BetterUI.ProcCoefficientCatalog.AddToSkill(myDef.skillName, "Explosion", 1f);
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Toolbot.ToolbotDash.OnEnter += On_ToolbotDashEnter;

--- a/AncientScepter/ScepterSkills/TreebotFireFruitSeed2.cs
+++ b/AncientScepter/ScepterSkills/TreebotFireFruitSeed2.cs
@@ -54,10 +54,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("TreebotBodyFireFruitSeed"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("TreebotBodyFireFruitSeed"));
+        } 
         internal override void LoadBehavior()
         {
             On.RoR2.HealthPickup.OnTriggerStay += HealthPickup_OnTriggerStay;

--- a/AncientScepter/ScepterSkills/TreebotFlower2_2.cs
+++ b/AncientScepter/ScepterSkills/TreebotFlower2_2.cs
@@ -41,10 +41,15 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("TreebotBodyFireFlower2"));
+                doBetterUI();
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("TreebotBodyFireFlower2"));
+        } 
         internal override void LoadBehavior()
         {
             On.EntityStates.Treebot.TreebotFlower.TreebotFlower2Projectile.RootPulse += On_TreebotFlower2RootPulse;

--- a/AncientScepter/ScepterSkills/VoidFiendCrush.cs
+++ b/AncientScepter/ScepterSkills/VoidFiendCrush.cs
@@ -75,13 +75,18 @@ namespace AncientScepter
 
             if (ModCompat.compatBetterUI)
             {
-                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CrushCorruption"));
-                BetterUI.ProcCoefficientCatalog.AddSkill(myCtxDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CrushHealth"));
+                doBetterUI();
             }
 
             targetBodyIndex = BodyCatalog.FindBodyIndex(targetBody);
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        internal void doBetterUI()
+        {
+                BetterUI.ProcCoefficientCatalog.AddSkill(myDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CrushCorruption"));
+                BetterUI.ProcCoefficientCatalog.AddSkill(myCtxDef.skillName, BetterUI.ProcCoefficientCatalog.GetProcCoefficientInfo("CrushHealth"));
+        } 
         internal override void LoadBehavior()
         {
             HealthComponent.onCharacterHealServer += HealNearby;


### PR DESCRIPTION
-  **Make registration (& application) of scepter skills slot agnostic.**
 Also adds an overload for RegisterScepterSkill that takes (replacementdef,bodyname,targetdef).
 This technically also allows a character to have a scepter replacement for multiple slots,though only one is applied and there is no priority system for it.
- **Allow other Heresy Items to be considered**
 Fixes #19 
- **Fix BetterUI Soft Compat**
The jit will throw if it sees a non-existent name even if it isn't
invoked,so they need to be quarantied. Fixes #20 , Fixes #16 