### PR TITLE
Fix side effect of previous fix.

### DIFF
--- a/AncientScepter/ScepterSkills/TreebotFireFruitSeed2.cs
+++ b/AncientScepter/ScepterSkills/TreebotFireFruitSeed2.cs
@@ -73,7 +73,7 @@ namespace AncientScepter
         {
             if (!NetworkServer.active) return;
             if (!damageReport.victimBody) return;
-            if (damageReport.attackerBody && damageReport.attackerBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (damageReport.attackerBody && damageReport.attackerBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 var victimBody = damageReport.victimBody;
                 GameObject gameObject = damageReport.victim.gameObject;


### PR DESCRIPTION
#26 moved the responsibility of executing scepter skills from possesion of the item to possession of the skilldef. TreebotFireFruitSeed2 places a check in a global code path so the result from the query for the skilldef now needs to be null-checked since characters without a corresponding Skill Slot can run it on some circumstances. The null conditional operator is ok here because GetSkill returns an explicit csharp `null` when the GenericSkill is missing.