### PR TITLE
Extra checks for upgraded GenericSkills.

### DIFF
--- a/AncientScepter/AncientScepterMain.cs
+++ b/AncientScepter/AncientScepterMain.cs
@@ -26,7 +26,7 @@ namespace AncientScepter
 
     public class AncientScepterMain : BaseUnityPlugin
     {
-        public const string ModVer = "1.1.21";
+        public const string ModVer = "1.1.22";
         public const string ModName = "StandaloneAncientScepter";
         public const string ModGuid = "com.DestroyedClone.AncientScepter";
 

--- a/AncientScepter/CHANGELOG.md
+++ b/AncientScepter/CHANGELOG.md
@@ -1,5 +1,10 @@
 ﻿
 ## Changelog
+`1.1.22`
+- Fixed Handling of cases where upgraded skill states are reused by other bodies.
+  - Specifically,fixes Incinerator/Flamethrower Drones erroring out on attack.
+- Fixed non-existent/old bodies causing issues when inside Rex's Chaotic Growth
+
 `1.1.21`
 - Better handling of broken defs from mods + logging
 - Added nullcheck to removeclassicitemsscepter method to  try to fix out of range exception

--- a/AncientScepter/ScepterSkills/ArtificerFlamethrower2.cs
+++ b/AncientScepter/ScepterSkills/ArtificerFlamethrower2.cs
@@ -123,7 +123,8 @@ namespace AncientScepter
             {
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<BulletAttack, EntityStates.Mage.Weapon.Flamethrower, BulletAttack>>((origAttack, state) => {
-                    if (state.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return origAttack;
+                    var skill = state.outer.commonComponents.characterBody?.skillLocator?.GetSkill(targetSlot);
+                    if (skill && skill.skillDef != myDef) return origAttack;
                     origAttack.hitCallback = (BulletAttack self, ref BulletAttack.BulletHit h) => {
                         ProjectileManager.instance.FireProjectile(new FireProjectileInfo
                         {

--- a/AncientScepter/ScepterSkills/ArtificerFlyUp2.cs
+++ b/AncientScepter/ScepterSkills/ArtificerFlyUp2.cs
@@ -63,7 +63,7 @@ namespace AncientScepter
         {
             var origRadius = FlyUpState.blastAttackRadius;
             var origDamage = FlyUpState.blastAttackDamageCoefficient;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 FlyUpState.blastAttackRadius *= 4f;
                 FlyUpState.blastAttackDamageCoefficient *= 2f;

--- a/AncientScepter/ScepterSkills/Bandit2ResetRevolver2.cs
+++ b/AncientScepter/ScepterSkills/Bandit2ResetRevolver2.cs
@@ -57,7 +57,7 @@ namespace AncientScepter
         {
             orig(self);
             bool isScepter = self is EntityStates.Bandit2.Weapon.FireSidearmResetRevolver
-               && self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef;
+               && self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef;
             if (isScepter)
             {
                 Ray aimRay = self.GetAimRay();

--- a/AncientScepter/ScepterSkills/Bandit2SkullRevolver2.cs
+++ b/AncientScepter/ScepterSkills/Bandit2SkullRevolver2.cs
@@ -186,7 +186,7 @@ namespace AncientScepter
         {
             if ((damageInfo.damageType & DamageType.GiveSkullOnKill) == DamageType.GiveSkullOnKill)
             {
-                if (self.body && self.body.master && damageInfo.attacker && damageInfo.attacker.GetComponent<HealthComponent>() && damageInfo.attacker.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot).skillDef == myDef)
+                if (self.body && self.body.master && damageInfo.attacker && damageInfo.attacker.GetComponent<HealthComponent>() && damageInfo.attacker.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
                 {
                     var attackerHC = damageInfo.attacker.GetComponent<HealthComponent>();
                     var baseAI = self.body.master.GetComponent<RoR2.CharacterAI.BaseAI>();

--- a/AncientScepter/ScepterSkills/CaptainAirstrike2.cs
+++ b/AncientScepter/ScepterSkills/CaptainAirstrike2.cs
@@ -95,7 +95,7 @@ namespace AncientScepter
             var isAirstrike = self is CallAirstrike1
                 || self is CallAirstrike2
                 || self is CallAirstrike3;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef && isAirstrike) return false;
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef && isAirstrike) return false;
             return orig(self);
         }
 
@@ -123,7 +123,7 @@ namespace AncientScepter
                 || self is CallAirstrike2
                 || self is CallAirstrike3;
 
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef && isAirstrike)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef && isAirstrike)
             {
                 self.damageCoefficient = 5f;
                 self.AddRecoil(-1f, 1f, -1f, 1f);
@@ -133,7 +133,7 @@ namespace AncientScepter
         private void On_SetupAirstrikeStateEnter(On.EntityStates.Captain.Weapon.SetupAirstrike.orig_OnEnter orig, EntityStates.Captain.Weapon.SetupAirstrike self) //exc
         {
             var origOverride = SetupAirstrike.primarySkillDef;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 SetupAirstrike.primarySkillDef = myCallDef;
             }

--- a/AncientScepter/ScepterSkills/CaptainAirstrikeAlt2.cs
+++ b/AncientScepter/ScepterSkills/CaptainAirstrikeAlt2.cs
@@ -226,7 +226,7 @@ namespace AncientScepter
         private void CallAirstrikeAlt_ModifyProjectile(On.EntityStates.Captain.Weapon.CallAirstrikeAlt.orig_ModifyProjectile orig, CallAirstrikeAlt self, ref FireProjectileInfo fireProjectileInfo)
         {
             orig(self, ref fireProjectileInfo);
-            bool isScepter = self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef;
+            bool isScepter = self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef;
             if (isScepter)
             {
                 fireProjectileInfo.projectilePrefab = airstrikePrefab;
@@ -245,7 +245,7 @@ namespace AncientScepter
         private void On_CallAirstrikeBaseEnter(On.EntityStates.Captain.Weapon.CallAirstrikeBase.orig_OnEnter orig, CallAirstrikeBase self)
         {
             orig(self);
-            bool isScepter = self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef
+            bool isScepter = self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef
                 && self is EntityStates.Captain.Weapon.CallAirstrikeAlt;
             if (isScepter)
             {
@@ -256,7 +256,7 @@ namespace AncientScepter
         private void On_SetupAirstrikeStateEnter(On.EntityStates.Captain.Weapon.SetupAirstrike.orig_OnEnter orig, EntityStates.Captain.Weapon.SetupAirstrike self) //exc
         {
             var origOverride = SetupAirstrike.primarySkillDef;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 SetupAirstrike.primarySkillDef = myCallDef;
             }

--- a/AncientScepter/ScepterSkills/CommandoBarrage2.cs
+++ b/AncientScepter/ScepterSkills/CommandoBarrage2.cs
@@ -71,7 +71,7 @@ namespace AncientScepter
 
         private void FireSweepBarrage_FixedUpdate(On.EntityStates.Commando.CommandoWeapon.FireSweepBarrage.orig_FixedUpdate orig, FireSweepBarrage self)
         {
-            if (self.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 self.FixedUpdate();
                 self.fireTimer -= Time.fixedDeltaTime;
@@ -98,7 +98,7 @@ namespace AncientScepter
 
         private void FireSweepBarrage_Fire(On.EntityStates.Commando.CommandoWeapon.FireSweepBarrage.orig_Fire orig, FireSweepBarrage self)
         {
-            if (self.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 if (self.totalBulletsFired < self.totalBulletsToFire)
                 {
@@ -178,7 +178,7 @@ namespace AncientScepter
         private void FireSweepBarrage_OnEnter(On.EntityStates.Commando.CommandoWeapon.FireSweepBarrage.orig_OnEnter orig, FireSweepBarrage self)
         {
             orig(self);
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 if (self.targetHurtboxes.Count == 0)
                 {
@@ -200,7 +200,7 @@ namespace AncientScepter
         private void On_FireBarrage_Enter(On.EntityStates.Commando.CommandoWeapon.FireBarrage.orig_OnEnter orig, FireBarrage self)
         {
             orig(self);
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 self.durationBetweenShots /= 2f;
                 self.bulletCount *= 2;
@@ -209,7 +209,7 @@ namespace AncientScepter
 
         private void On_FireBarrage_FireBullet(On.EntityStates.Commando.CommandoWeapon.FireBarrage.orig_FireBullet orig, FireBarrage self)
         {
-            bool hasScep = self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef;
+            bool hasScep = self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef;
             var origAmp = FireBarrage.recoilAmplitude;
             var origRadius = FireBarrage.bulletRadius;
             if (hasScep)

--- a/AncientScepter/ScepterSkills/CommandoGrenade2.cs
+++ b/AncientScepter/ScepterSkills/CommandoGrenade2.cs
@@ -73,7 +73,7 @@ namespace AncientScepter
             var cc = self.outer.commonComponents;
             bool isBoosted = self is ThrowGrenade
                 && Util.HasEffectiveAuthority(self.outer.networkIdentity)
-                && cc.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef;
+                && cc.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef;
             if (isBoosted) self.projectilePrefab = projReplacer;
             orig(self);
             if (isBoosted)

--- a/AncientScepter/ScepterSkills/CrocoDisease2.cs
+++ b/AncientScepter/ScepterSkills/CrocoDisease2.cs
@@ -81,7 +81,7 @@ namespace AncientScepter
         private void On_LightningOrbArrival(On.RoR2.Orbs.LightningOrb.orig_OnArrival orig, LightningOrb self)
         {
             orig(self);
-            if (self.lightningType != LightningOrb.LightningType.CrocoDisease || self.attacker?.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot).skillDef != myDef) return;
+            if (self.lightningType != LightningOrb.LightningType.CrocoDisease || self.attacker?.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return;
             if (!self.target || !self.target.healthComponent) return;
 
             var cpt = self.target.healthComponent.gameObject.GetComponentInChildren<DiseaseWard>()?.gameObject;

--- a/AncientScepter/ScepterSkills/HuntressBallista2.cs
+++ b/AncientScepter/ScepterSkills/HuntressBallista2.cs
@@ -82,7 +82,7 @@ namespace AncientScepter
         private void On_FireArrowSnipeFire(On.EntityStates.Huntress.Weapon.FireArrowSnipe.orig_FireBullet orig, FireArrowSnipe self, Ray aimRay)
         {
             orig(self, aimRay);
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return;
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return;
 
             for (var i = 1; i < 6; i++)
             {
@@ -105,7 +105,7 @@ namespace AncientScepter
             orig(self);
             var sloc = self.outer.commonComponents.skillLocator;
             if (!sloc || !sloc.primary) return;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 sloc.primary.UnsetSkillOverride(self, AimArrowSnipe.primarySkillDef, GenericSkill.SkillOverridePriority.Contextual);
                 sloc.primary.SetSkillOverride(self, myCtxDef, GenericSkill.SkillOverridePriority.Contextual);
@@ -117,7 +117,7 @@ namespace AncientScepter
             orig(self);
             var sloc = self.outer.commonComponents.skillLocator;
             if (!sloc || !sloc.primary) return;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
                 sloc.primary.UnsetSkillOverride(self, myCtxDef, GenericSkill.SkillOverridePriority.Contextual);
         }
     }

--- a/AncientScepter/ScepterSkills/HuntressRain2.cs
+++ b/AncientScepter/ScepterSkills/HuntressRain2.cs
@@ -86,7 +86,7 @@ namespace AncientScepter
         private void On_ArrowRain_DoFireArrowRain(On.EntityStates.Huntress.ArrowRain.orig_DoFireArrowRain orig, ArrowRain self)
         {
             var origPrefab = ArrowRain.projectilePrefab;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef) ArrowRain.projectilePrefab = projReplacer;
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef) ArrowRain.projectilePrefab = projReplacer;
             orig(self);
             ArrowRain.projectilePrefab = origPrefab;
         }

--- a/AncientScepter/ScepterSkills/LoaderChargeFist2.cs
+++ b/AncientScepter/ScepterSkills/LoaderChargeFist2.cs
@@ -66,7 +66,7 @@ namespace AncientScepter
         {
             orig(self);
             if (!(self is SwingChargedFist)) return;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 self.minPunchForce *= 7f;
                 self.maxPunchForce *= 7f;
@@ -78,7 +78,7 @@ namespace AncientScepter
 
         private void BaseSwingChargedFist_OnMeleeHitAuthority(On.EntityStates.Loader.BaseSwingChargedFist.orig_OnMeleeHitAuthority orig, BaseSwingChargedFist self)
         {
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return;
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return;
             var mTsf = self.outer.commonComponents.modelLocator?.modelTransform?.GetComponent<ChildLocator>()?.FindChild(self.swingEffectMuzzleString);
             EffectManager.SpawnEffect(Resources.Load<GameObject>("prefabs/effects/omnieffect/OmniExplosionVFXCommandoGrenade"),
                 new EffectData

--- a/AncientScepter/ScepterSkills/LoaderChargeZapFist2.cs
+++ b/AncientScepter/ScepterSkills/LoaderChargeZapFist2.cs
@@ -76,7 +76,7 @@ namespace AncientScepter
         private void On_BaseChargeFistEnter(On.EntityStates.Loader.BaseChargeFist.orig_OnEnter orig, BaseChargeFist self)
         {
             orig(self);
-            if (!(self is ChargeZapFist) || self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return;
+            if (!(self is ChargeZapFist) || self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return;
             var mTsf = self.outer.commonComponents.modelLocator?.modelTransform?.GetComponent<ChildLocator>()?.FindChild(BaseChargeFist.chargeVfxChildLocatorName);
             EffectManager.SpawnEffect(Resources.Load<GameObject>("prefabs/effects/MageLightningBombExplosion"),
                 new EffectData
@@ -96,7 +96,7 @@ namespace AncientScepter
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<GameObject, SwingZapFist, GameObject>>((origProj, state) =>
                 {
-                    if (state.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return origProj;
+                    if (state.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return origProj;
                     var mTsf = state.outer.commonComponents.modelLocator?.modelTransform?.GetComponent<ChildLocator>()?.FindChild(state.swingEffectMuzzleString);
                     EffectManager.SpawnEffect(Resources.Load<GameObject>("prefabs/effects/ImpactEffects/LightningStrikeImpact"),
                         new EffectData

--- a/AncientScepter/ScepterSkills/MercEvis2.cs
+++ b/AncientScepter/ScepterSkills/MercEvis2.cs
@@ -65,7 +65,7 @@ namespace AncientScepter
         private void Evt_GEMOnCharacterDeathGlobal(DamageReport rep)
         {
             var attackerState = rep.attackerBody?.GetComponent<EntityStateMachine>()?.state;
-            if (attackerState is Evis asEvis && rep.attackerBody.skillLocator.GetSkill(targetSlot).skillDef == myDef
+            if (attackerState is Evis asEvis && rep.attackerBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef
                 && Vector3.Distance(rep.attackerBody.transform.position, rep.victim.transform.position) < Evis.maxRadius)
             {
                 if (rep.attackerBody.inputBank.skill4.down == false)
@@ -81,7 +81,7 @@ namespace AncientScepter
         private void On_EvisFixedUpdate(On.EntityStates.Merc.Evis.orig_FixedUpdate orig, Evis self)
         {
             var origDuration = Evis.duration;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef) Evis.duration *= 2f;
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef) Evis.duration *= 2f;
             orig(self);
             Evis.duration = origDuration;
         }

--- a/AncientScepter/ScepterSkills/MercEvisProjectile2.cs
+++ b/AncientScepter/ScepterSkills/MercEvisProjectile2.cs
@@ -63,7 +63,7 @@ namespace AncientScepter
         private void On_FireFMJEnter(On.EntityStates.GenericProjectileBaseState.orig_OnEnter orig, EntityStates.GenericProjectileBaseState self)
         {
             orig(self);
-            if (!(self is EntityStates.Merc.Weapon.ThrowEvisProjectile) || self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return;
+            if (!(self is EntityStates.Merc.Weapon.ThrowEvisProjectile) || self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return;
             if (!self.outer.commonComponents.skillLocator?.special) return;
             var fireCount = self.outer.commonComponents.skillLocator.special.stock;
             self.outer.commonComponents.skillLocator.special.stock = 0;

--- a/AncientScepter/ScepterSkills/RailgunnerCryo2.cs
+++ b/AncientScepter/ScepterSkills/RailgunnerCryo2.cs
@@ -94,7 +94,7 @@ namespace AncientScepter
         private void BaseFireSnipe_OnExit(On.EntityStates.Railgunner.Weapon.BaseFireSnipe.orig_OnExit orig, EntityStates.Railgunner.Weapon.BaseFireSnipe self)
         {
             orig(self);
-            if (self is EntityStates.Railgunner.Weapon.FireSnipeCryo && self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self is EntityStates.Railgunner.Weapon.FireSnipeCryo && self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 var cb = self.outer.commonComponents.characterBody;
                 if (cb)
@@ -107,7 +107,7 @@ namespace AncientScepter
         private void FireSnipeCryo_ModifyBullet(On.EntityStates.Railgunner.Weapon.FireSnipeCryo.orig_ModifyBullet orig, EntityStates.Railgunner.Weapon.FireSnipeCryo self, BulletAttack bulletAttack)
         {
             orig(self, bulletAttack);
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 bulletAttack.AddModdedDamageType(CustomDamageTypes.ScepterSlow80For30DT);
 

--- a/AncientScepter/ScepterSkills/RailgunnerSuper2.cs
+++ b/AncientScepter/ScepterSkills/RailgunnerSuper2.cs
@@ -84,7 +84,7 @@ namespace AncientScepter
         private void BaseCharged_OnEnter(On.EntityStates.Railgunner.Backpack.BaseCharged.orig_OnEnter orig, EntityStates.Railgunner.Backpack.BaseCharged self)
         {
             var cachedOverride = self.primaryOverride;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 if (self is EntityStates.Railgunner.Backpack.ChargedSuper)
                 {
@@ -102,7 +102,7 @@ namespace AncientScepter
         private void BaseCharged_OnExit(On.EntityStates.Railgunner.Backpack.BaseCharged.orig_OnExit orig, EntityStates.Railgunner.Backpack.BaseCharged self)
         {
             var cachedOverride = self.primaryOverride;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 if (self is EntityStates.Railgunner.Backpack.ChargedSuper)
                 {
@@ -120,7 +120,7 @@ namespace AncientScepter
         private void Offline_OnEnter(On.EntityStates.Railgunner.Backpack.Offline.orig_OnEnter orig, EntityStates.Railgunner.Backpack.Offline self)
         {
             var origDuration = self.baseDuration;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 self.baseDuration = Mathf.Max(0, self.baseDuration - 1);
             }
@@ -152,7 +152,7 @@ namespace AncientScepter
         private void BaseFireSnipe_ModifyBullet(On.EntityStates.Railgunner.Weapon.BaseFireSnipe.orig_ModifyBullet orig, EntityStates.Railgunner.Weapon.BaseFireSnipe self, BulletAttack bulletAttack)
         {
             //var cachedProcCoefficient = bulletAttack.procCoefficient;
-            if (self is EntityStates.Railgunner.Weapon.FireSnipeSuper && self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self is EntityStates.Railgunner.Weapon.FireSnipeSuper && self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 bulletAttack.AddModdedDamageType(CustomDamageTypes.ScepterDestroy10ArmorDT);
                 bulletAttack.procCoefficient += 0.5f;

--- a/AncientScepter/ScepterSkills/ToolbotDash2.cs
+++ b/AncientScepter/ScepterSkills/ToolbotDash2.cs
@@ -77,7 +77,7 @@ namespace AncientScepter
         {
             orig(self);
             if (!self.outer.commonComponents.characterBody) return;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef != myDef) return;
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef != myDef) return;
             var cpt = self.outer.commonComponents.characterBody.GetComponent<ScepterToolbotDashTracker>();
             if (!cpt) cpt = self.outer.commonComponents.characterBody.gameObject.AddComponent<ScepterToolbotDashTracker>();
             cpt.enabled = true;

--- a/AncientScepter/ScepterSkills/TreebotFlower2_2.cs
+++ b/AncientScepter/ScepterSkills/TreebotFlower2_2.cs
@@ -79,8 +79,9 @@ namespace AncientScepter
             orig(self);
             TreebotFlower2Projectile.radius = origRadius;
             if (!isBoosted) return;
-            self.rootedBodies.ForEach(cb =>
+            self.rootedBodies?.ForEach(cb =>
             {
+                if(cb){
                 var nbi = AncientScepterItem.instance.rng.NextElementUniform(new[] {
                     RoR2Content.Buffs.Bleeding,
                     RoR2Content.Buffs.ClayGoo,
@@ -91,9 +92,9 @@ namespace AncientScepter
                     RoR2Content.Buffs.Pulverized
                 }); //todo: freezebuff
                 if (nbi == RoR2Content.Buffs.OnFire) DotController.InflictDot(cb.gameObject, self.owner, DotController.DotIndex.Burn, 1.5f, 1f);
-                if (nbi == RoR2Content.Buffs.Bleeding) DotController.InflictDot(cb.gameObject, self.owner, DotController.DotIndex.Bleed, 1.5f, 1f);
-                cb.AddTimedBuff(nbi, 1.5f);
-            });
+                else if (nbi == RoR2Content.Buffs.Bleeding) DotController.InflictDot(cb.gameObject, self.owner, DotController.DotIndex.Bleed, 1.5f, 1f);
+                else cb.AddTimedBuff(nbi, 1.5f);
+            }});
         }
     }
 }

--- a/AncientScepter/ScepterSkills/TreebotFlower2_2.cs
+++ b/AncientScepter/ScepterSkills/TreebotFlower2_2.cs
@@ -66,14 +66,14 @@ namespace AncientScepter
         {
             var owner = self.outer.GetComponent<ProjectileController>()?.owner;
             var origRadius = TreebotFlower2Projectile.radius;
-            if (owner.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot).skillDef == myDef) TreebotFlower2Projectile.radius *= 2f;
+            if (owner.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot)?.skillDef == myDef) TreebotFlower2Projectile.radius *= 2f;
             orig(self);
             TreebotFlower2Projectile.radius = origRadius;
         }
 
         private void On_TreebotFlower2RootPulse(On.EntityStates.Treebot.TreebotFlower.TreebotFlower2Projectile.orig_RootPulse orig, TreebotFlower2Projectile self)
         {
-            var isBoosted = self.owner?.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot).skillDef == myDef;
+            var isBoosted = self.owner?.GetComponent<CharacterBody>().skillLocator.GetSkill(targetSlot)?.skillDef == myDef;
             var origRadius = TreebotFlower2Projectile.radius;
             if (isBoosted) TreebotFlower2Projectile.radius *= 2f;
             orig(self);

--- a/AncientScepter/ScepterSkills/VoidFiendCrush.cs
+++ b/AncientScepter/ScepterSkills/VoidFiendCrush.cs
@@ -87,7 +87,7 @@ namespace AncientScepter
         private void CorruptMode_OnExit(On.EntityStates.VoidSurvivor.CorruptMode.CorruptMode.orig_OnExit orig, EntityStates.VoidSurvivor.CorruptMode.CorruptMode self)
         {
             var cachedSkillDef = self.specialOverrideSkillDef;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 self.specialOverrideSkillDef = myCtxDef;
                 self.characterBody.skillLocator.special.UnsetSkillOverride(self, cachedSkillDef, GenericSkill.SkillOverridePriority.Upgrade);
@@ -99,7 +99,7 @@ namespace AncientScepter
         private void CorruptMode_OnEnter(On.EntityStates.VoidSurvivor.CorruptMode.CorruptMode.orig_OnEnter orig, EntityStates.VoidSurvivor.CorruptMode.CorruptMode self)
         {
             var cachedSkillDef = self.specialOverrideSkillDef;
-            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (self.outer.commonComponents.characterBody.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 self.specialOverrideSkillDef = myCtxDef;
                 self.characterBody.skillLocator.special.UnsetSkillOverride(self, cachedSkillDef, GenericSkill.SkillOverridePriority.Upgrade);
@@ -113,7 +113,7 @@ namespace AncientScepter
             orig(healthComponent, damageInfo);
             if (damageInfo.procChainMask.HasProc(ProcType.VoidSurvivorCrush))
             {
-                if (healthComponent.body.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+                if (healthComponent.body.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
                 {
                     DamageInfo damageInfoToDeal = new DamageInfo
                     {
@@ -164,7 +164,7 @@ namespace AncientScepter
         //From HealingWard.cs
         private void HealNearby(HealthComponent healthComponent, float healAmount, ProcChainMask procChainMask)
         {
-            if (procChainMask.HasProc(ProcType.VoidSurvivorCrush) && healthComponent.body.skillLocator.GetSkill(targetSlot).skillDef == myDef)
+            if (procChainMask.HasProc(ProcType.VoidSurvivorCrush) && healthComponent.body.skillLocator.GetSkill(targetSlot)?.skillDef == myDef)
             {
                 ReadOnlyCollection<TeamComponent> teamMembers = TeamComponent.GetTeamMembers(healthComponent.body.teamComponent.teamIndex);
                 float num = 25 * 25;

--- a/AncientScepter/manifest.json
+++ b/AncientScepter/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "StandaloneAncientScepter",
-  "version_number": "1.1.21",
+  "version_number": "1.1.22",
   "website_url": "https://github.com/DestroyedClone/AncientScepter",
-  "description": "1.1.21 - slight fixes | A full port of ThinkInvisible's Ancient Scepter, complete with a custom model, item displays, and no extra dependencies.",
+  "description": "1.1.22 - slighter fixes  | A full port of ThinkInvisible's Ancient Scepter, complete with a custom model, item displays, and no extra dependencies.",
   "dependencies": [
     "bbepis-BepInExPack-5.4.2103",
     "tristanmcpherson-R2API-4.3.5",


### PR DESCRIPTION
This fixes a case where states targeted by scepter can be re-used by the game for different bodies,which can break assumptions that are normally always true (such as a skill existing in the slot it's in). 
The specific instance of this bug that was found was Incinerator Drones using Artificer's flamethrower state for their attack.